### PR TITLE
text label fix

### DIFF
--- a/bbox_visualizer/bbox_visualizer.py
+++ b/bbox_visualizer/bbox_visualizer.py
@@ -262,6 +262,8 @@ def draw_multiple_rectangles(img,
 def add_multiple_labels(img,
                         labels,
                         bboxes,
+                        size=1,
+                        thickness=2,
                         draw_bg=True,
                         text_bg_color=(255, 255, 255),
                         text_color=(0, 0, 0),
@@ -290,9 +292,8 @@ def add_multiple_labels(img,
     ndarray
         the image with the labels written
     """
-
     for label, bbox in zip(labels, bboxes):
-        img = add_label(img, label, bbox, draw_bg, text_bg_color, text_color,
+        img = add_label(img, label, bbox, size, thickness, draw_bg, text_bg_color, text_color,
                         top)
 
     return img


### PR DESCRIPTION
The current version has a problem where keyword arguments and positional arguments get mixed up, resulting in an error when adjusting the size of the label text. I have fixed this issue. Additionally, I have also enabled the adjustment of the size through arguments in the add_multiple_labels function.