### PR TITLE
Fix numpy input handling and label placement from v1.0.0 review

### DIFF
--- a/bbox_visualizer/core/_utils.py
+++ b/bbox_visualizer/core/_utils.py
@@ -1,5 +1,6 @@
 """Internal utilities for bbox-visualizer."""
 
+import numbers
 from collections.abc import Sequence
 from functools import lru_cache
 
@@ -39,11 +40,14 @@ def _validate_bbox(bbox: list[int]) -> None:
         )
 
 
-def _validate_color(color: Sequence[int]) -> None:
-    """Validate that a color is a valid BGR sequence.
+def _validate_color(color: Sequence[int]) -> tuple[int, int, int]:
+    """Validate a BGR color sequence and normalize it to a tuple of ints.
 
     Args:
         color: BGR color sequence to validate
+
+    Returns:
+        The color as a tuple of built-in ints (cv2 rejects numpy scalars)
 
     Raises:
         ValueError: If color is not a valid BGR sequence
@@ -51,8 +55,12 @@ def _validate_color(color: Sequence[int]) -> None:
     """
     if not hasattr(color, "__len__") or len(color) != 3:
         raise ValueError("Color must be a sequence of 3 integers (BGR)")
-    if not all(isinstance(c, int) and 0 <= c <= 255 for c in color):
+    # numbers.Integral also admits numpy integer scalars, e.g. colors
+    # sampled from image pixels (np.uint8)
+    if not all(isinstance(c, numbers.Integral) and 0 <= c <= 255 for c in color):
         raise ValueError("Color values must be integers between 0 and 255")
+    b, g, r = (int(c) for c in color)
+    return (b, g, r)
 
 
 def _convert_bbox_to_voc(

--- a/bbox_visualizer/core/flags.py
+++ b/bbox_visualizer/core/flags.py
@@ -52,8 +52,8 @@ def add_T_label(
         New image with added T-shaped label; the input image is not modified
 
     """
-    _validate_color(text_bg_color)
-    _validate_color(text_color)
+    text_bg_color = _validate_color(text_bg_color)
+    text_color = _validate_color(text_color)
     bbox = _check_and_modify_bbox(bbox, img.shape, bbox_format=bbox_format)
     img = img.copy()
     (label_width, label_height), baseline = _get_text_size(label, size, thickness)
@@ -149,9 +149,9 @@ def draw_flag_with_label(
         New image with added flag label; the input image is not modified
 
     """
-    _validate_color(line_color)
-    _validate_color(text_bg_color)
-    _validate_color(text_color)
+    line_color = _validate_color(line_color)
+    text_bg_color = _validate_color(text_bg_color)
+    text_color = _validate_color(text_color)
     bbox = _check_and_modify_bbox(bbox, img.shape, bbox_format=bbox_format)
     img = img.copy()
     (label_width, label_height), baseline = _get_text_size(label, size, thickness)
@@ -224,13 +224,14 @@ def add_multiple_T_labels(
         New image with all T-shaped labels added; the input image is not modified
 
     """
-    if not bboxes or not labels:
+    # len() instead of truthiness: numpy arrays raise on ambiguous bool()
+    if len(bboxes) == 0 or len(labels) == 0:
         raise ValueError("Lists of bounding boxes and labels cannot be empty")
     if len(bboxes) != len(labels):
         raise ValueError("Number of bounding boxes must match number of labels")
 
-    _validate_color(text_bg_color)
-    _validate_color(text_color)
+    text_bg_color = _validate_color(text_bg_color)
+    text_color = _validate_color(text_color)
     for label, bbox in zip(labels, bboxes, strict=True):
         img = add_T_label(
             img,
@@ -274,14 +275,15 @@ def draw_multiple_flags_with_labels(
         New image with all flag labels added; the input image is not modified
 
     """
-    if not bboxes or not labels:
+    # len() instead of truthiness: numpy arrays raise on ambiguous bool()
+    if len(bboxes) == 0 or len(labels) == 0:
         raise ValueError("Lists of bounding boxes and labels cannot be empty")
     if len(bboxes) != len(labels):
         raise ValueError("Number of bounding boxes must match number of labels")
 
-    _validate_color(line_color)
-    _validate_color(text_bg_color)
-    _validate_color(text_color)
+    line_color = _validate_color(line_color)
+    text_bg_color = _validate_color(text_bg_color)
+    text_color = _validate_color(text_color)
     for label, bbox in zip(labels, bboxes, strict=True):
         img = draw_flag_with_label(
             img,

--- a/bbox_visualizer/core/labels.py
+++ b/bbox_visualizer/core/labels.py
@@ -45,8 +45,8 @@ def add_label(
         New image with added label; the input image is not modified
 
     """
-    _validate_color(text_bg_color)
-    _validate_color(text_color)
+    text_bg_color = _validate_color(text_bg_color)
+    text_color = _validate_color(text_color)
     bbox = _check_and_modify_bbox(bbox, img.shape, bbox_format=bbox_format)
     img = img.copy()
 
@@ -57,7 +57,9 @@ def add_label(
     # Include the font baseline so descenders (p, q, g, ...) stay inside the bg
     bg_height = text_height + baseline + 2 * padding
 
-    label_above = top and bbox[1] - text_height > text_height
+    # Compare against the full background height so the label only goes above
+    # the box when the whole background fits inside the image
+    label_above = top and bbox[1] >= bg_height
     bg_x1 = bbox[0]
     bg_y1 = bbox[1] - bg_height if label_above else bbox[1]
     bg_x2 = bg_x1 + bg_width
@@ -118,13 +120,14 @@ def add_multiple_labels(
         New image with all labels added; the input image is not modified
 
     """
-    if not bboxes or not labels:
+    # len() instead of truthiness: numpy arrays raise on ambiguous bool()
+    if len(bboxes) == 0 or len(labels) == 0:
         raise ValueError("Lists of bounding boxes and labels cannot be empty")
     if len(bboxes) != len(labels):
         raise ValueError("Number of bounding boxes must match number of labels")
 
-    _validate_color(text_bg_color)
-    _validate_color(text_color)
+    text_bg_color = _validate_color(text_bg_color)
+    text_color = _validate_color(text_color)
 
     # Validate and convert all bboxes to VOC format up front
     converted_bboxes = [

--- a/bbox_visualizer/core/rectangle.py
+++ b/bbox_visualizer/core/rectangle.py
@@ -35,7 +35,7 @@ def draw_rectangle(
         New image with drawn rectangle; the input image is not modified
 
     """
-    _validate_color(bbox_color)
+    bbox_color = _validate_color(bbox_color)
     bbox = _check_and_modify_bbox(bbox, img.shape, bbox_format=bbox_format)
 
     output = img.copy()
@@ -90,7 +90,8 @@ def draw_multiple_rectangles(
         New image with all rectangles drawn; the input image is not modified
 
     """
-    if not bboxes:
+    # len() instead of truthiness: numpy arrays raise on ambiguous bool()
+    if len(bboxes) == 0:
         raise ValueError("List of bounding boxes cannot be empty")
 
     per_box_colors = len(bbox_color) > 0 and isinstance(bbox_color[0], tuple | list)
@@ -105,8 +106,7 @@ def draw_multiple_rectangles(
         colors = [tuple(color) for color in color_seq]
     else:
         colors = [cast("tuple[int, int, int]", bbox_color)] * len(bboxes)
-    for color in colors:
-        _validate_color(color)
+    colors = [_validate_color(color) for color in colors]
 
     # Validate and modify all bboxes
     validated_bboxes = [

--- a/tests/test_bbox_visualizer.py
+++ b/tests/test_bbox_visualizer.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 from bbox_visualizer.core import flags, labels, rectangle
-from bbox_visualizer.core._utils import _convert_bbox_to_voc
+from bbox_visualizer.core._utils import _convert_bbox_to_voc, _get_text_size
 
 
 @pytest.fixture
@@ -551,3 +551,31 @@ def test_fallback_warning_uses_module_logger(sample_image, sample_label, caplog)
         assert len(caplog.records) == 0
     finally:
         logging.getLogger("bbox_visualizer").setLevel(logging.NOTSET)
+
+
+def test_numpy_array_bboxes(sample_image):
+    """A numpy array of boxes works everywhere a list of boxes does."""
+    bboxes = np.array([[10, 10, 30, 30], [50, 50, 70, 70]])
+    names = ["a", "b"]
+    rectangle.draw_multiple_rectangles(sample_image, bboxes)
+    labels.add_multiple_labels(sample_image, names, bboxes)
+    flags.add_multiple_T_labels(sample_image, names, bboxes)
+    flags.draw_multiple_flags_with_labels(sample_image, names, bboxes)
+
+
+def test_numpy_integer_color(sample_image, sample_bbox):
+    """Colors made of numpy integer scalars (e.g. sampled pixels) are valid."""
+    color = tuple(np.uint8(c) for c in (255, 0, 0))
+    result = rectangle.draw_rectangle(sample_image, sample_bbox, bbox_color=color)
+    assert (result == (255, 0, 0)).all(axis=2).any()
+
+
+def test_label_falls_back_inside_when_bg_does_not_fit_above(sample_image):
+    """The label goes inside the box when the full background can't fit above."""
+    (_, text_height), baseline = _get_text_size("test", 0.3, 1)
+    bg_height = text_height + baseline + 2 * 5  # mirrors add_label's padding
+    y_min = bg_height - 1  # one pixel short of fitting the background above
+    result = labels.add_label(
+        sample_image, "test", [10, y_min, 90, 90], size=0.3, thickness=1
+    )
+    assert not result[:y_min].any()


### PR DESCRIPTION
Follow-up to #72, addressing the Copilot review comments before tagging v1.0.0:

- **numpy bbox arrays**: `if not bboxes` raised `ValueError: truth value is ambiguous` when a `np.ndarray` of boxes was passed; switched to `len()` checks in `rectangle`, `labels`, and `flags`.
- **numpy integer colors**: `_validate_color` rejected `np.uint8`/`np.int64` channels (e.g. colors sampled from image pixels). It now accepts `numbers.Integral` and normalizes to built-in ints, since cv2 5.0 rejects numpy scalars outright.
- **label-above placement**: `add_label` compared available space against `text_height` but drew a taller background (`text_height + baseline + padding`), so small labels near the top edge were clipped off-image instead of falling back inside the box. The check now uses the full background height.

Tests added for all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)