### PR TITLE
Restore ValueError for None inputs in multi-object functions

### DIFF
--- a/bbox_visualizer/core/flags.py
+++ b/bbox_visualizer/core/flags.py
@@ -225,7 +225,7 @@ def add_multiple_T_labels(
 
     """
     # len() instead of truthiness: numpy arrays raise on ambiguous bool()
-    if len(bboxes) == 0 or len(labels) == 0:
+    if bboxes is None or labels is None or len(bboxes) == 0 or len(labels) == 0:
         raise ValueError("Lists of bounding boxes and labels cannot be empty")
     if len(bboxes) != len(labels):
         raise ValueError("Number of bounding boxes must match number of labels")
@@ -276,7 +276,7 @@ def draw_multiple_flags_with_labels(
 
     """
     # len() instead of truthiness: numpy arrays raise on ambiguous bool()
-    if len(bboxes) == 0 or len(labels) == 0:
+    if bboxes is None or labels is None or len(bboxes) == 0 or len(labels) == 0:
         raise ValueError("Lists of bounding boxes and labels cannot be empty")
     if len(bboxes) != len(labels):
         raise ValueError("Number of bounding boxes must match number of labels")

--- a/bbox_visualizer/core/labels.py
+++ b/bbox_visualizer/core/labels.py
@@ -121,7 +121,7 @@ def add_multiple_labels(
 
     """
     # len() instead of truthiness: numpy arrays raise on ambiguous bool()
-    if len(bboxes) == 0 or len(labels) == 0:
+    if bboxes is None or labels is None or len(bboxes) == 0 or len(labels) == 0:
         raise ValueError("Lists of bounding boxes and labels cannot be empty")
     if len(bboxes) != len(labels):
         raise ValueError("Number of bounding boxes must match number of labels")

--- a/bbox_visualizer/core/rectangle.py
+++ b/bbox_visualizer/core/rectangle.py
@@ -91,7 +91,7 @@ def draw_multiple_rectangles(
 
     """
     # len() instead of truthiness: numpy arrays raise on ambiguous bool()
-    if len(bboxes) == 0:
+    if bboxes is None or len(bboxes) == 0:
         raise ValueError("List of bounding boxes cannot be empty")
 
     per_box_colors = len(bbox_color) > 0 and isinstance(bbox_color[0], tuple | list)

--- a/tests/test_bbox_visualizer.py
+++ b/tests/test_bbox_visualizer.py
@@ -553,6 +553,18 @@ def test_fallback_warning_uses_module_logger(sample_image, sample_label, caplog)
         logging.getLogger("bbox_visualizer").setLevel(logging.NOTSET)
 
 
+def test_none_inputs_raise_value_error(sample_image):
+    """None bboxes/labels raise the intended ValueError, not TypeError."""
+    with pytest.raises(ValueError, match="cannot be empty"):
+        rectangle.draw_multiple_rectangles(sample_image, None)
+    with pytest.raises(ValueError, match="cannot be empty"):
+        labels.add_multiple_labels(sample_image, None, None)
+    with pytest.raises(ValueError, match="cannot be empty"):
+        flags.add_multiple_T_labels(sample_image, None, None)
+    with pytest.raises(ValueError, match="cannot be empty"):
+        flags.draw_multiple_flags_with_labels(sample_image, None, None)
+
+
 def test_numpy_array_bboxes(sample_image):
     """A numpy array of boxes works everywhere a list of boxes does."""
     bboxes = np.array([[10, 10, 30, 30], [50, 50, 70, 70]])


### PR DESCRIPTION
Follow-up to #73, addressing the Copilot review comments there: the `len()`-based empty checks raised `TypeError: object of type 'NoneType' has no len()` for `None` inputs, where previously (and elsewhere in the codebase, e.g. `_validate_bbox`) `None` produces a `ValueError`. Adds explicit `is None` guards at the four call sites plus a test, keeping the error contract uniform for v1.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)