### PR TITLE
Update docs for v1.0.0 changes

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,10 @@ cv2.waitKey(0)
 
 ## Examples
 
-Check out the Jupyter notebook examples in the `examples/` directory:
+Check out the runnable scripts and Jupyter notebooks in the `examples/` directory:
 
+- `quickstart.py` - Minimal example on a blank canvas
+- `single_object.py` - Every single-object label style
+- `multiple_objects.py` - Every multi-object label style
 - `single_object_example.ipynb` - Basic usage with single objects
 - `multiple_objects_example.ipynb` - Working with multiple bounding boxes

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,5 +1,7 @@
 # Installation
 
+bbox-visualizer requires Python 3.10 or newer.
+
 ## Recommended Installation (using uv)
 
 `uv` is an extremely fast Python package installer and resolver. To install bbox-visualizer using uv:
@@ -31,7 +33,13 @@ The source for bbox-visualizer can be downloaded from the [Github repo](https://
 You can clone the public repository:
 
 ```console
-git clone git://github.com/shoumikchow/bbox-visualizer
+git clone https://github.com/shoumikchow/bbox-visualizer.git
+```
+
+Or, if you have SSH keys set up with GitHub:
+
+```console
+git clone git@github.com:shoumikchow/bbox-visualizer.git
 ```
 
 Once you have a copy of the source, you can install it with uv (recommended):

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -60,6 +60,31 @@ image = bbv.draw_box(image, bbox, is_opaque=True, alpha=0.5)
     as aliases for `draw_box` and `draw_multiple_boxes` respectively. Both naming
     conventions work identically.
 
+## Bounding Box Formats
+
+Every drawing function accepts a `bbox_format` keyword argument. The default is
+Pascal VOC.
+
+| `bbox_format` | Coordinates | Scale |
+|---------------|-------------|-------|
+| `"voc"` (default) | `[x_min, y_min, x_max, y_max]` | absolute pixels |
+| `"coco"` | `[x_min, y_min, width, height]` | absolute pixels |
+| `"yolo"` | `[x_center, y_center, width, height]` | normalized to `[0, 1]` |
+
+```python
+# COCO format: [x_min, y_min, width, height]
+image = bbv.draw_box(image, [150, 100, 300, 200], bbox_format="coco")
+
+# YOLO format: [x_center, y_center, width, height], normalized to [0, 1].
+# Image dimensions are read from the image, so no extra arguments are needed.
+image = bbv.draw_box(image, [0.5, 0.4, 0.3, 0.25], bbox_format="yolo")
+
+# Works with the multiple-object variants too
+image = bbv.draw_multiple_boxes(image, coco_bboxes, bbox_format="coco")
+```
+
+Internally all formats are converted to Pascal VOC before drawing.
+
 ## Adding Labels
 
 Simple labels:
@@ -200,10 +225,14 @@ for det in detections:
 
 **Bounding box format errors**
 
-Make sure your bounding boxes are in (x1, y1, x2, y2) format where:
+By default, bounding boxes are expected in Pascal VOC format (x1, y1, x2, y2) where:
 
 - x1, y1: top-left corner coordinates
 - x2, y2: bottom-right corner coordinates
+
+If your boxes are in COCO or YOLO format, pass `bbox_format="coco"` or
+`bbox_format="yolo"` instead of converting them yourself (see
+[Bounding Box Formats](#bounding-box-formats)).
 
 **Color format issues**
 


### PR DESCRIPTION
Brings the MkDocs site up to date with the v1.0.0 release:

- **usage.md**: documents COCO/YOLO `bbox_format` support (was README-only) and fixes the troubleshooting section that still claimed boxes must be in VOC format
- **index.md**: lists the runnable example scripts (`quickstart.py`, `single_object.py`, `multiple_objects.py`) alongside the notebooks
- **installation.md**: states the Python 3.10 minimum and replaces the dead `git://` clone URL with HTTPS and SSH

🤖 Generated with [Claude Code](https://claude.com/claude-code)