### PR TITLE
Harden CI security: fix tag injection, pin actions to SHAs, bump open…

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,12 +10,12 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0  # Fetch all history for proper versioning
-      
+
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
           
@@ -31,8 +31,9 @@ jobs:
           uv pip install build hatchling hatch-vcs
           
       - name: Verify tag format
+        env:
+          TAG_NAME: ${{ github.ref_name }}
         run: |
-          TAG_NAME=${{ github.ref_name }}
           if [[ ! $TAG_NAME =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Error: Tag name '$TAG_NAME' does not match required format 'vX.Y.Z'"
             exit 1
@@ -44,7 +45,7 @@ jobs:
           python -m build
         
       - name: Store dist artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: dist
           path: dist/
@@ -61,13 +62,13 @@ jobs:
     
     steps:
       - name: Download dist artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: dist
           path: dist
 
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           verbose: true
           print-hash: true 

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -4,18 +4,19 @@ on:
   push:
     branches: [master, dev]
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   autofix:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
 
       - name: Sync project
         run: uv sync --extra dev
@@ -26,7 +27,7 @@ jobs:
           uv run ruff check --fix bbox_visualizer tests examples
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@4e1beaa7521e8b457b572c090b25bd3db56bf1c5 # v5.0.3
         with:
           commit-message: "style: format and lint code with Ruff"
           title: "style: format and lint code with Ruff"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,10 +15,10 @@ jobs:
       matrix:
         python-version: ['3.10', '3.12', '3.14']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Visualization",
 ]
 dependencies = [
-    "opencv-python>=4.1.0.25",
+    "opencv-python>=4.8.1.78",
     "numpy>=1.19.0",
 ]
 


### PR DESCRIPTION
…cv floor

  - publish.yml: pass tag name via env instead of shell interpolation
  - Pin all GitHub Actions to commit SHAs (with version comments)
  - ruff.yml: scope write permissions to the autofix job
  - pyproject.toml: raise opencv-python floor to >=4.8.1.78 (CVE-2023-4863, libwebp heap overflow in bundled builds)